### PR TITLE
Add Windows Support

### DIFF
--- a/cmd/kuberlr/main.go
+++ b/cmd/kuberlr/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"github.com/flavio/kuberlr/internal/osexec"
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
@@ -68,6 +68,6 @@ func kubectlWrapperMode() {
 	}
 
 	childArgs := append([]string{kubectlBin}, os.Args[1:]...)
-	err = syscall.Exec(kubectlBin, childArgs, os.Environ())
+	err = osexec.Exec(kubectlBin, childArgs, os.Environ())
 	klog.Fatal(err)
 }

--- a/cmd/kuberlr/main.go
+++ b/cmd/kuberlr/main.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"github.com/flavio/kuberlr/internal/osexec"
+	"github.com/spf13/cobra"
+	"k8s.io/klog"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/spf13/cobra"
-	"k8s.io/klog"
 
 	"github.com/flavio/kuberlr/cmd/kuberlr/flags"
 	"github.com/flavio/kuberlr/internal/config"
@@ -17,7 +16,8 @@ import (
 func main() {
 	klog.InitFlags(nil)
 
-	if strings.HasSuffix(os.Args[0], "kubectl") {
+	binary := osexec.TrimExt(filepath.Base(os.Args[0]))
+	if strings.HasSuffix(binary, "kubectl") {
 		kubectlWrapperMode()
 	}
 	nativeMode()

--- a/internal/common/naming.go
+++ b/internal/common/naming.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"github.com/flavio/kuberlr/internal/osexec"
 
 	"github.com/blang/semver"
 )
@@ -17,11 +18,11 @@ const KubectlSystemNamingScheme = "kubectl%d.%d"
 // BuildKubectlNameForLocalBin returns how kuberlr will name the kubectl binary
 // with the specified version when downloading that to the user home
 func BuildKubectlNameForLocalBin(v semver.Version) string {
-	return fmt.Sprintf(KubectlLocalNamingScheme, v.Major, v.Minor, v.Patch)
+	return fmt.Sprintf(KubectlLocalNamingScheme+osexec.Ext, v.Major, v.Minor, v.Patch)
 }
 
 // BuildKubectlNameForSystemBin returns how kuberlr expects system-wide
 // kubectl binaries to be named
 func BuildKubectlNameForSystemBin(version semver.Version) string {
-	return fmt.Sprintf(KubectlSystemNamingScheme, version.Major, version.Minor)
+	return fmt.Sprintf(KubectlSystemNamingScheme+osexec.Ext, version.Major, version.Minor)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,11 +19,7 @@ type Cfg struct {
 // directories
 func NewCfg() *Cfg {
 	return &Cfg{
-		Paths: []string{
-			"/usr/etc/",
-			"/etc/",
-			filepath.Join(common.HomeDir(), ".kuberlr"),
-		},
+		Paths: configPaths,
 	}
 }
 

--- a/internal/config/paths_unix.go
+++ b/internal/config/paths_unix.go
@@ -1,0 +1,14 @@
+//+build linux darwin
+
+package config
+
+import (
+	"github.com/flavio/kuberlr/internal/common"
+	"path/filepath"
+)
+
+var configPaths = []string{
+	"/usr/etc/",
+	"/etc/",
+	filepath.Join(common.HomeDir(), ".kuberlr"),
+}

--- a/internal/config/paths_windows.go
+++ b/internal/config/paths_windows.go
@@ -1,0 +1,15 @@
+// +build windows
+
+package config
+
+import (
+	"github.com/flavio/kuberlr/internal/common"
+	"os"
+	"path/filepath"
+)
+
+var configPaths = []string{
+	filepath.Join(os.Getenv("APPDATA"), "kuberlr"),
+	filepath.Join(os.Getenv("PROGRAMDATA"), "kuberlr"),
+	filepath.Join(common.HomeDir(), ".kuberlr"),
+}

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -2,12 +2,13 @@ package downloader
 
 import (
 	"fmt"
+	"github.com/flavio/kuberlr/internal/osexec"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -72,12 +73,13 @@ func (d *Downloder) GetKubectlBinary(version semver.Version, destination string)
 func (d *Downloder) kubectlDownloadURL(v semver.Version) (string, error) {
 	// Example: https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectlI
 	u, err := url.Parse(fmt.Sprintf(
-		"https://storage.googleapis.com/kubernetes-release/release/v%d.%d.%d/bin/%s/%s/kubectl",
+		"https://storage.googleapis.com/kubernetes-release/release/v%d.%d.%d/bin/%s/%s/kubectl%s",
 		v.Major,
 		v.Minor,
 		v.Patch,
 		runtime.GOOS,
 		runtime.GOARCH,
+		osexec.Ext,
 	))
 	if err != nil {
 		return "", err

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -58,9 +58,9 @@ func (d *Downloder) GetKubectlBinary(version semver.Version, destination string)
 		return err
 	}
 
-	if _, err := os.Stat(path.Dir(destination)); err != nil {
+	if _, err := os.Stat(filepath.Dir(destination)); err != nil {
 		if os.IsNotExist(err) {
-			err = os.MkdirAll(path.Dir(destination), os.ModePerm)
+			err = os.MkdirAll(filepath.Dir(destination), os.ModePerm)
 		}
 		if err != nil {
 			return err

--- a/internal/finder/kubectl_finder.go
+++ b/internal/finder/kubectl_finder.go
@@ -3,6 +3,7 @@ package finder
 import (
 	"errors"
 	"fmt"
+	"github.com/flavio/kuberlr/internal/osexec"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -107,7 +108,7 @@ func (f *KubectlFinder) MostRecentKubectlAvailable() (KubectlBinary, error) {
 func inferLocalKubectlVersion(filename string) (semver.Version, error) {
 	var major, minor, patch uint64
 	n, err := fmt.Sscanf(
-		filename,
+		osexec.TrimExt(filename),
 		common.KubectlLocalNamingScheme,
 		&major,
 		&minor,
@@ -127,7 +128,7 @@ func inferLocalKubectlVersion(filename string) (semver.Version, error) {
 func inferSystemKubectlVersion(filename string) (semver.Version, error) {
 	var major, minor uint64
 	n, err := fmt.Sscanf(
-		filename,
+		osexec.TrimExt(filename),
 		common.KubectlSystemNamingScheme,
 		&major,
 		&minor)

--- a/internal/finder/versioner.go
+++ b/internal/finder/versioner.go
@@ -2,11 +2,10 @@ package finder
 
 import (
 	"errors"
-	"path/filepath"
-
 	"github.com/flavio/kuberlr/internal/common"
 	"github.com/flavio/kuberlr/internal/downloader"
 	"github.com/flavio/kuberlr/internal/kubehelper"
+	"path/filepath"
 
 	"github.com/blang/semver"
 	"k8s.io/klog"

--- a/internal/osexec/ext_unix.go
+++ b/internal/osexec/ext_unix.go
@@ -1,0 +1,12 @@
+// +build linux darwin
+
+package osexec
+
+// Ext is the filename extension of binaries
+const Ext = ""
+
+// TrimExt returns the filename unaltered
+// there is no binary extension appended to files on Linux and Mac
+func TrimExt(filename string) string {
+	return filename
+}

--- a/internal/osexec/ext_windows.go
+++ b/internal/osexec/ext_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package osexec
+
+import "strings"
+
+// Ext is the filename extension of binaries
+const Ext = ".exe"
+
+// TrimExt returns the filename with the extension removed
+func TrimExt(filename string) string {
+	return strings.TrimSuffix(filename, Ext)
+}

--- a/internal/osexec/osexec_unix.go
+++ b/internal/osexec/osexec_unix.go
@@ -1,0 +1,23 @@
+// +build linux darwin
+
+package osexec
+
+import (
+	"syscall"
+)
+
+// Exec executes the program referred to by pathname with the given arguments and environment.
+// On darwin and linux, this uses the 'execve' syscall.  (See: http://man7.org/linux/man-pages/man2/execve.2.html)
+//
+// In summary, this causes the program that is currently being run by the calling
+// process to be replaced with a new program, with newly initialized stack, heap, and
+// (initialized and uninitialized) data segments.
+//
+// If successful, this function never returns because the current program will "terminate" immediately.
+func Exec(pathname string, argv []string, env []string) error {
+	err := syscall.Exec(pathname, argv, env)
+	if err != nil {
+		return err
+	}
+	panic("execve: unexpected return")
+}

--- a/internal/osexec/osexec_windows.go
+++ b/internal/osexec/osexec_windows.go
@@ -1,0 +1,74 @@
+// +build windows
+
+package osexec
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+)
+
+
+
+// Exec executes the program referred to by pathname with the given arguments and environment.
+// Windows doesn't support the unix-like `execve`, so we try to emulate it as best we can.
+//
+// Instead, this function will:
+// 1. spawn a new child process
+// 2. attach to stdin/out/err
+// 3. forward signals
+// 4. wait for process to exit, and call os.Exit() with the exit code of the child process.
+//
+// If successful, this function never returns, because the current program will terminate.
+func Exec(pathname string, argv []string, env []string) error {
+	// Windows doesn't support the unix-like `execve`
+	// even the unix-compat layer basically devolves to CreateProcess + ExitProcess
+
+	args := argv
+	if len(args) > 0 {
+		args = args[1:] // strip off the command name from the argv
+	}
+
+	cmd := exec.Command(pathname, args...)
+	cmd.Env = env
+
+	// attach stdin/err/out
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+
+	// forward signals to child
+	sigCh := make(chan os.Signal)
+	signal.Notify(sigCh)
+	defer func() {
+		signal.Stop(sigCh)
+		close(sigCh)
+	}()
+	go func() {
+		for sig := range sigCh {
+			if proc := cmd.Process; proc != nil {
+				proc.Signal(sig)
+			}
+		}
+	}()
+
+	// Run the child process
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// child process exited with a failure, and we can hopefully grab that exit code
+			if exitErr.ProcessState != nil {
+				os.Exit(exitErr.ProcessState.ExitCode())
+			}
+			// assume exit code 1, conventional for errors
+			os.Exit(1)
+		}
+		// probably child process never started, return the error
+		return err
+	}
+	os.Exit(0)
+	// never reached
+	return nil
+}

--- a/internal/osexec/osexec_windows.go
+++ b/internal/osexec/osexec_windows.go
@@ -7,10 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"strings"
 )
-
-
 
 // Exec executes the program referred to by pathname with the given arguments and environment.
 // Windows doesn't support the unix-like `execve`, so we try to emulate it as best we can.


### PR DESCRIPTION
Add support for running `kuberlr` on Windows.

- Add `execve` replacement for Windows, since `syscall.Exec` does not exist, and there is no Windows equivalent.
- Manage the `.exe` extension
- Use different config paths for global config locations