### PR TITLE
fix: set progress bar desc to shorter string

### DIFF
--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -67,7 +67,7 @@ func (d *Downloder) GetKubectlBinary(version semver.Version, destination string)
 		}
 	}
 
-	return d.download(downloadURL, destination, 0755)
+	return d.download(fmt.Sprintf("kubectl%s%s", version, osexec.Ext), downloadURL, destination, 0755)
 }
 
 func (d *Downloder) kubectlDownloadURL(v semver.Version) (string, error) {
@@ -88,7 +88,7 @@ func (d *Downloder) kubectlDownloadURL(v semver.Version) (string, error) {
 	return u.String(), nil
 }
 
-func (d *Downloder) download(urlToGet, destination string, mode os.FileMode) error {
+func (d *Downloder) download(desc, urlToGet, destination string, mode os.FileMode) error {
 	req, err := http.NewRequest("GET", urlToGet, nil)
 	if err != nil {
 		return fmt.Errorf(
@@ -122,11 +122,13 @@ func (d *Downloder) download(urlToGet, destination string, mode os.FileMode) err
 
 	// write progress to stderr, writing to stdout would
 	// break bash/zsh/shell completion
+	fmt.Fprintf(os.Stderr, "Downloading %s\n", urlToGet)
 	bar := progressbar.NewOptions(
 		int(resp.ContentLength),
-		progressbar.OptionSetDescription(urlToGet),
+		progressbar.OptionSetDescription(desc),
 		progressbar.OptionSetWriter(os.Stderr),
 		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetWidth(40),
 		progressbar.OptionThrottle(10*time.Millisecond),
 		progressbar.OptionShowCount(),
 		progressbar.OptionOnCompletion(func() {


### PR DESCRIPTION
Set the progress bar description to a shorter string. The full URL to the kubectl binary causes the progress bar to break. Setting it to something more meaningful like the version of kubectl currently downloading seems like a reasonable alternative.

## Before 
![kuberlr-progress](https://user-images.githubusercontent.com/222027/87169700-5da5f500-c29e-11ea-9ba2-dfd8a2cde4af.gif)

## After
![kuberlr-progress](https://user-images.githubusercontent.com/222027/87169688-57b01400-c29e-11ea-9c68-eecbf8d05c0e.gif)