### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ RM = rm
 BINPATH       := $(abspath ./bin)
 GOBINPATH     := $(shell $(GO) env GOPATH)/bin
 COMMIT        := $(shell git rev-parse HEAD)
-BUILD_DATE    := $(shell date +%Y%m%d)
+DATE_FMT = +%Y%m%d
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" $(DATE_FMT))
+else
+    BUILD_DATE ?= $(shell date $(DATE_FMT))
+endif
 # TAG can be provided as an envvar (provided in the .spec file)
 TAG           ?= $(shell git describe --tags --exact-match HEAD 2> /dev/null)
 # CLOSEST_TAG can be provided as an envvar (provided in the .spec file)


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call only works with GNU date.

This PR was done while working on reproducible builds for openSUSE.