### PR TITLE
Enable building universal binaries for macos

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
     - amd64
     - arm
     - arm64
+universal_binaries:
+  - replace: false
 archives:
 - format_overrides:
   - goos: windows


### PR DESCRIPTION
This adds a `kuberlr_<version>_darwin_all.tar.gz` (containing a macOS universal binary that works on x86_64 and arm64) to releases. For compatibility, it _keeps_ the separate x86_64 and arm64 binaries around too.

This would let people grab a singular executable without worrying about which architecture is in use.

I pushed a test build at https://github.com/mook-as/kuberlr/releases/tag/v0.0.2 if that helps looking at results.