### PR TITLE
verify old kubectl binaries with sha1, and new ones with sha512

### DIFF
--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -203,7 +203,7 @@ func (d *Downloder) download(desc string, urlToGet string, useSha512 bool, desti
 	)
 	hasher := sha512.New()
 	if !useSha512 {
-		hasher := sha1.New()
+		hasher = sha1.New()
 	}
 
 	_, err = io.Copy(io.MultiWriter(temporaryDestinationFile, bar, hasher), resp.Body)

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -83,11 +83,11 @@ func (d *Downloder) GetKubectlBinary(version semver.Version, destination string)
 	const maxNumTries = 3
 	const timeToSleepOnRetryPerIter = 10 // seconds
 
-	// - sha1 is avaliable in range [1.0.0, 1.18)
-	// - sha256 is avaliable from v1.16.0
-	// - sha512 is avaliable from 1.12.0
-	isNew, err := semver.ParseRange(">=1.12.0")
-	useSha512 := err != nil || isNew(version)
+	// - sha1 is available in range [1.0.0, 1.18)
+	// - sha256 is available from v1.16.0
+	// - sha512 is available from 1.12.0
+	isNew, parseErr := semver.ParseRange(">=1.12.0")
+	useSha512 := parseErr != nil || isNew(version)
 
 	for iter := 1; iter <= maxNumTries; iter++ {
 		downloadURL, err := d.kubectlDownloadURL(version)

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -87,7 +87,7 @@ func (d *Downloder) GetKubectlBinary(version semver.Version, destination string)
 	// - sha256 is avaliable from v1.16.0
 	// - sha512 is avaliable from 1.12.0
 	isNew, err := semver.ParseRange(">=1.12.0")
-	const useSha512 = err != nil || isNew(version)
+	useSha512 := err != nil || isNew(version)
 
 	for iter := 1; iter <= maxNumTries; iter++ {
 		downloadURL, err := d.kubectlDownloadURL(version)

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -145,7 +145,7 @@ func (d *Downloder) kubectlDownloadURL(version semver.Version) (string, error) {
 	return url.String(), nil
 }
 
-func (d *Downloder) download(desc, urlToGet, useSha512 bool, destination string, mode os.FileMode) error { //nolint: funlen
+func (d *Downloder) download(desc string, urlToGet string, useSha512 bool, destination string, mode os.FileMode) error { //nolint: funlen
 	shaURLToGet := urlToGet + ".sha512"
 	if !useSha512 {
 		shaURLToGet = urlToGet + ".sha1"

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -2,7 +2,7 @@ package downloader
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // sha1 is now we needed
 	"crypto/sha512"
 	"encoding/hex"
 	"errors"
@@ -203,6 +203,7 @@ func (d *Downloder) download(desc string, urlToGet string, useSha512 bool, desti
 	)
 	hasher := sha512.New()
 	if !useSha512 {
+		//nolint:gosec // sha1 is now we needed
 		hasher = sha1.New()
 	}
 

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -146,11 +146,9 @@ func (d *Downloder) kubectlDownloadURL(version semver.Version) (string, error) {
 }
 
 func (d *Downloder) download(desc, urlToGet, useSha512 bool, destination string, mode os.FileMode) error { //nolint: funlen
-	shaURLToGet := urlToGet
-	if useSha512 {
-		shaURLToGet += ".sha512"
-	} else {
-		shaURLToGet += ".sha1"
+	shaURLToGet := urlToGet + ".sha512"
+	if !useSha512 {
+		shaURLToGet = urlToGet + ".sha1"
 	}
 	shaExpected, err := d.getContentsOfURL(shaURLToGet)
 	if err != nil {

--- a/internal/downloader/hashing.go
+++ b/internal/downloader/hashing.go
@@ -1,0 +1,44 @@
+package downloader
+
+import (
+	"crypto/sha1" //nolint:gosec // sha1 is needed by old releases of kubectl
+	"crypto/sha512"
+	"hash"
+
+	"github.com/blang/semver/v4"
+)
+
+// Hashing contains the hashing details for the downloader
+type Hashing struct {
+	// Suffix of the file containing the hash
+	Suffix string
+
+	// Hasher is the hash calculator to use
+	Hasher hash.Hash
+}
+
+// NewHashing returns the hashing details for the downloader
+//
+//nolint:gosec // sha1 is needed by old releases of kubectl
+func NewHashing(version semver.Version) (*Hashing, error) {
+	// - sha1 is available in range [1.0.0, 1.18)
+	// - sha256 is available from v1.16.0
+	// - sha512 is available from 1.12.0
+
+	rangeConstraint, parseErr := semver.ParseRange(">=1.12.0")
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	if rangeConstraint(version) {
+		return &Hashing{
+			Suffix: ".sha512",
+			Hasher: sha512.New(),
+		}, nil
+	}
+
+	// we have to resort to sha1
+	return &Hashing{
+		Suffix: ".sha1",
+		Hasher: sha1.New(),
+	}, nil
+}

--- a/internal/downloader/hashing_test.go
+++ b/internal/downloader/hashing_test.go
@@ -1,0 +1,59 @@
+package downloader
+
+import (
+	"bytes"
+	"crypto/sha1" //nolint:gosec // sha1 is needed by old releases of kubectl
+	"crypto/sha512"
+	"testing"
+
+	"github.com/blang/semver/v4"
+)
+
+func TestHashing(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		expectedSuffix string
+		inputData      []byte
+		expectedHash   []byte
+	}{
+		{
+			name:           "sha1",
+			version:        "1.11.0",
+			expectedSuffix: ".sha1",
+			inputData:      []byte("hello"),
+			expectedHash:   sha1.New().Sum([]byte("hello")), //nolint:gosec // sha1 is needed by old releases of kubectl
+		},
+		{
+			name:           "sha512",
+			version:        "1.12.0",
+			expectedSuffix: ".sha512",
+			inputData:      []byte("hello"),
+			expectedHash:   sha512.New().Sum([]byte("hello")),
+		},
+	}
+
+	for _, test := range tests {
+		tableTest := test // ensure tt is correctly scoped when used in function literal
+		t.Run(tableTest.name, func(t *testing.T) {
+			version, err := semver.Parse(tableTest.version)
+			if err != nil {
+				t.Fatalf("failed to parse version %s: %v", tableTest.version, err)
+			}
+
+			hashing, err := NewHashing(version)
+			if err != nil {
+				t.Fatalf("failed to create hashing: %v", err)
+			}
+
+			if hashing.Suffix != tableTest.expectedSuffix {
+				t.Errorf("expected suffix %s, got %s", tableTest.expectedSuffix, hashing.Suffix)
+			}
+
+			hash := hashing.Hasher.Sum(tableTest.inputData)
+			if !bytes.Equal(hash, tableTest.expectedHash) {
+				t.Errorf("expected hash %v, got %v", tableTest.expectedHash, hash)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix #80 