### PR TITLE
Add Dockerfile and publish image to ghcr.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.idea/
+.github/
+dist/
+package/
+coverage.out
+.dockerenv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: 1.22.x
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.0.0
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           distribution: goreleaser
           version: latest
@@ -39,22 +39,22 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           REGISTRY: ${{ vars.registry || 'ghcr.io' }}
           username: ${{ vars.username || github.actor }}
           password: ${{ secrets.IMAGE_REPO_PASSWORD || secrets.GITHUB_TOKEN }}
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       - name: Build and push
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
         id: build-push
@@ -71,7 +71,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@210c1913531870065f03ce1f9440dd87bc0938cd # v1.4.0
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: Release Tag (goreleaser and container image)
 
 on:
   push:
@@ -32,3 +32,39 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          REGISTRY: ${{ vars.registry || 'ghcr.io' }}
+          username: ${{ vars.username || github.actor }}
+          password: ${{ secrets.IMAGE_REPO_PASSWORD || secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+      - name: Build and push
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        id: build-push
+        with:
+          context: .
+          file: package/Dockerfile
+          build-args: |
+            PROJECT_PATH=github.com/${{ github.repository }}
+            VERSION=${{ github.ref_name	}}
+            TAG=${{ github.ref_name	}}
+          platforms: "linux/amd64,linux/arm64,linux/s390x"
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
       packages: write
       id-token: write
       contents: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -66,5 +67,12 @@ jobs:
             TAG=${{ github.ref_name	}}
           platforms: "linux/amd64,linux/arm64,linux/s390x"
           push: true
+          provenance: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod download

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,3 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
 version: 2
 before:
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ TARGET_PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x
 
 RUNNER := docker
 IMAGE_BUILDER := $(RUNNER) buildx
-MACHINE := rancher
+MACHINE := kwctl
 
 REPO ?= flavio
 IMAGE = $(REPO)/kuberlr:$(TAG)

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,0 +1,70 @@
+# If desired this can be set to specific tag by passing an arg
+ARG BCI_VERSION=latest
+FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
+
+# Image that provides cross compilation tooling.
+FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 AS xx
+
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS build
+
+ARG PROJECT_PATH
+ARG VERSION
+ARG BUILD_DATE
+ARG TAG
+
+COPY --from=xx / /
+
+WORKDIR /app
+COPY . .
+
+ENV CGO_ENABLED=0
+RUN xx-go --wrap && mkdir -p /run/lock
+RUN xx-go mod download && \
+    xx-go build -ldflags "-X=${PROJECT_PATH}/pkg/kuberlr.Version=${VERSION} \
+        -X=${PROJECT_PATH}/pkg/kuberlr.BuildDate=${BUILD_DATE:-$(date +%Y%m%d)} \
+        -X=${PROJECT_PATH}/pkg/kuberlr.Tag=${TAG}" \
+        -o ./bin/kuberlr ./cmd/kuberlr
+RUN xx-verify --static ./bin/kuberlr
+
+FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS zypper
+
+RUN mkdir /chroot
+COPY --from=final / /chroot/
+
+# The final image does not contain zypper, --installroot is used to
+# install all artefacts within a dir (/chroot) that can then be copied
+# over to a scratch image.
+RUN zypper --non-interactive refresh && \
+    zypper --installroot /chroot -n rm busybox-vi busybox-links && \
+    zypper --installroot /chroot -n in bash-completion && \
+    zypper --installroot /chroot clean -a && \
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/etc/zypp/
+
+COPY --from=build /app/bin/kuberlr /chroot/bin/kuberlr
+RUN cd /chroot/bin && ln -s ./kuberlr ./kubectl
+
+RUN useradd -u 1000 -U -m kuberlr \
+    && cp /etc/passwd /chroot/etc/passwd \
+    && cp /etc/group /chroot/etc/group \
+    && cp -r /home/kuberlr /chroot/home/kuberlr \
+    && echo '. /etc/profile.d/bash_completion.sh' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'alias k="kubectl"' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'alias ks="kubectl -n kube-system"' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'source <(kubectl completion bash)' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'LANG=en_US.UTF-8' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'PS1="> "' >> /chroot/home/kuberlr/.bashrc \
+    && mkdir /chroot/home/kuberlr/.kube \
+    && mkdir /chroot/home/kuberlr/.kuberlr \
+    && touch /chroot/home/kuberlr/.kuberlr/kuberlr.conf \
+    && echo "AllowDownload = true" >> /chroot/home/kuberlr/.kuberlr/kuberlr.conf \
+    && echo "Timeout = 12" >> /chroot/home/kuberlr/.kuberlr/kuberlr.conf \
+    && chown -R 1000:1000 /chroot/home/kuberlr
+
+FROM scratch
+COPY --from=zypper /chroot /
+
+USER kuberlr
+
+WORKDIR /home/kuberlr
+ENTRYPOINT ["/bin/kuberlr"]
+CMD ["help"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -28,6 +28,13 @@ RUN xx-verify --static ./bin/kuberlr
 
 FROM registry.suse.com/bci/bci-base:${BCI_VERSION} AS zypper
 
+# Seed the skel dir with bash completion for kuberlr and kubectl
+# Now when the user is created in later steps these are included.
+COPY --from=build /app/bin/kuberlr /tmp/kuberlr
+RUN mkdir -p /usr/etc/skel && ln -s /tmp/kuberlr /tmp/kubectl && \
+    /tmp/kuberlr completion bash > /usr/etc/skel/.kuberlr_bash_completion && \
+    /tmp/kubectl completion bash > /usr/etc/skel/.kubectl_bash_completion
+
 RUN mkdir /chroot
 COPY --from=final / /chroot/
 
@@ -47,13 +54,13 @@ RUN useradd -u 1000 -U -m kuberlr \
     && cp /etc/passwd /chroot/etc/passwd \
     && cp /etc/group /chroot/etc/group \
     && cp -r /home/kuberlr /chroot/home/kuberlr \
+    && echo 'LANG=en_US.UTF-8' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'PS1="> "' >> /chroot/home/kuberlr/.bashrc \
     && echo '. /etc/profile.d/bash_completion.sh' >> /chroot/home/kuberlr/.bashrc \
     && echo 'alias k="kubectl"' >> /chroot/home/kuberlr/.bashrc \
     && echo 'alias ks="kubectl -n kube-system"' >> /chroot/home/kuberlr/.bashrc \
-    && echo 'source <(kuberlr completion bash)' >> /chroot/home/kuberlr/.bashrc \
-    && echo 'source <(kubectl completion bash)' >> /chroot/home/kuberlr/.bashrc \
-    && echo 'LANG=en_US.UTF-8' >> /chroot/home/kuberlr/.bashrc \
-    && echo 'PS1="> "' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'source ~/.kuberlr_bash_completion' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'source ~/.kubectl_bash_completion' >> /chroot/home/kuberlr/.bashrc \
     && mkdir /chroot/home/kuberlr/.kube \
     && mkdir /chroot/home/kuberlr/.kuberlr \
     && touch /chroot/home/kuberlr/.kuberlr/kuberlr.conf \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -50,6 +50,7 @@ RUN useradd -u 1000 -U -m kuberlr \
     && echo '. /etc/profile.d/bash_completion.sh' >> /chroot/home/kuberlr/.bashrc \
     && echo 'alias k="kubectl"' >> /chroot/home/kuberlr/.bashrc \
     && echo 'alias ks="kubectl -n kube-system"' >> /chroot/home/kuberlr/.bashrc \
+    && echo 'source <(kuberlr completion bash)' >> /chroot/home/kuberlr/.bashrc \
     && echo 'source <(kubectl completion bash)' >> /chroot/home/kuberlr/.bashrc \
     && echo 'LANG=en_US.UTF-8' >> /chroot/home/kuberlr/.bashrc \
     && echo 'PS1="> "' >> /chroot/home/kuberlr/.bashrc \


### PR DESCRIPTION
Per title, this PR seeks to add a dockerfile to build the container image of this repo.

I know `goreleaser` has an image building integration, but opted to not use that due to how simple it is. I wasn't sure there would be enough freedom to customize the image since it appears to mainly drop the binary in the image and go. Where as we will benefit from the image using `bash` to enable bash completion features.

This is related to these efforts for rancher: https://github.com/rancher/rancher/issues/43760