### PR TITLE
feat: Support environment variables for config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,7 @@ Timeout = 1
 # Default "https://dl.k8s.io"
 KubeMirrorUrl = "https://dl.k8s.io"
 ```
+
+The behaviour can also be adjusted by using environment variables matching the
+config file: `KUBERLR_ALLOWDOWNLOAD`, `KUBERLR_SYSTEMPATH`, `KUBERLR_TIMEOUT`,
+`KUBERLR_KUBEMIRRORURL`, and so on.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -33,6 +34,11 @@ func (c *Cfg) Load() (*viper.Viper, error) {
 	v.SetDefault("KubeMirrorUrl", "https://dl.k8s.io")
 
 	v.SetConfigType("toml")
+
+	// read environment variables, they take precedence
+	v.AutomaticEnv()
+	v.SetEnvPrefix("KUBERLR")
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 
 	if len(c.Paths) == 0 {
 		return v, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,7 +41,7 @@ func writeConfig(path, data string) error {
 	return os.WriteFile(
 		filepath.Join(path, "kuberlr.conf"),
 		[]byte(data),
-		0600)
+		0o600)
 }
 
 func TestOnlySystemConfigExists(t *testing.T) {
@@ -103,6 +103,33 @@ func TestHomeConfigOverridesSystemOne(t *testing.T) {
 	}
 	if v.GetBool("AllowDownload") != true {
 		t.Error("Expected configuration value wasn't found")
+	}
+}
+
+func TestEnvironmentVariables(t *testing.T) {
+	td, err := setup()
+	if err != nil {
+		t.Error(err)
+	}
+	defer teardown(td)
+
+	err = writeConfig(td.FakeHome, "AllowDownload = false")
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Setenv("KUBERLR_ALLOWDOWNLOAD", "true")
+
+	c := Cfg{
+		Paths: []string{},
+	}
+
+	v, err := c.Load()
+	if err != nil {
+		t.Errorf("Unexpected error loading config: %v", err)
+	}
+	if v.GetBool("AllowDownload") != true {
+		t.Error("env var wasn't taken into account")
 	}
 }
 


### PR DESCRIPTION
Fix: https://github.com/flavio/kuberlr/issues/153.

Instead of adding a new `--allow-download` flag as stated on the issue, enable Viper to work with environment variables. 

Kuberlr will honour environment variables with a name matching the key uppercased and prefixed with `KUBRERLR` (like `KUBERLR_ALLOWDOWNLOAD`) and use them for the config settings.

These environment variables take precedence over the config file settings.