### PR TITLE
Set the right initial permissions for the download dirs

### DIFF
--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -98,7 +98,7 @@ func (d *Downloder) GetKubectlBinary(version semver.Version, destination string)
 
 		if _, err = os.Stat(filepath.Dir(destination)); err != nil {
 			if os.IsNotExist(err) {
-				err = os.MkdirAll(filepath.Dir(destination), os.ModeDir)
+				err = os.MkdirAll(filepath.Dir(destination), 0750)
 			}
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR sets the right initial permissions for the download dirs.

Before this PR, if we git clone this repo and run `go run ./cmd/kuberlr kubectl`, we will see the following errors:
```bash
$ go run ./cmd/kuberlr kubectl
I0704 16:18:21.135572  681781 versioner.go:115] Right kubectl missing, downloading version 1.33.2
F0704 16:18:21.135867  681781 main.go:81] mkdir /home/<username>/.kuberlr/linux-amd64: permission denied
exit status 255
$ go run ./cmd/kuberlr kubectl
F0704 16:18:35.917452  682022 main.go:67] stat /home/<username>/.kuberlr/kuberlr.conf: permission denied
exit status 255
```