### PR TITLE
Improve error reporting

### DIFF
--- a/cmd/kuberlr/main.go
+++ b/cmd/kuberlr/main.go
@@ -64,24 +64,24 @@ func kubectlWrapperMode(args []string) {
 	cfg := config.NewCfg()
 	v, err := cfg.Load()
 	if err != nil {
-		klog.Fatal(err)
+		klog.Fatalf("kuberlr: load config: %v", err)
 	}
 
 	kubectlFinder := finder.NewKubectlFinder("", v.GetString("SystemPath"))
 	versioner := finder.NewVersioner(kubectlFinder)
 	version, err := versioner.KubectlVersionToUse(v.GetInt64("Timeout"))
 	if err != nil {
-		klog.Fatal(err)
+		klog.Fatalf("kuberlr: find kubectl version to use: %v", err)
 	}
 
 	kubectlBin, err := versioner.EnsureCompatibleKubectlAvailable(
 		version,
 		v.GetBool("AllowDownload"))
 	if err != nil {
-		klog.Fatal(err)
+		klog.Fatalf("kuberlr: ensure compatible kubectl available: %v", err)
 	}
 
 	childArgs := append([]string{kubectlBin}, args...)
 	err = osexec.Exec(kubectlBin, childArgs, os.Environ())
-	klog.Fatal(err)
+	klog.Fatalf("kuberlr: execute kubectl binary located at %s: %v", kubectlBin, err)
 }


### PR DESCRIPTION
I am using rancher desktop and encountered the following error:

```bash
$ kubectl --kubeconfig /tmp/ttt/kube-config.yaml
F0704 15:37:38.788239   29025 main.go:86] permission denied
```

This can be really confusing if the user doesn't realize the `kubectl` provided by rancher desktop is a `kuberlr`.

This PR improves the error reporting by adding more information to the message. After this PR, the error above will be displayed as:
```bash
F0704 16:43:42.292731  689970 main.go:86] kuberlr: execute kubectl binary located at /home/<username>/.kuberlr/linux-amd64/kubectl1.33.2: permission denied
```

As a result, users can distinguish kuberlr's errors from kubectl's errors more easily.