### PR TITLE
Add `UseLatestIfNoCompatible` option (#209)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ The configuration file is written using the [TOML format](https://github.com/tom
 # Allow the download of missing kubectl binaries from kubernetes' upstream mirror
 AllowDownload = true
 
+# When NO compatible local kubectl is found, opt-in to using the NEWEST local kubectl
+# instead of failing in these cases:
+#   1) downloads are disabled (AllowDownload = false), OR
+#   2) a download attempt fails (e.g., no network, blocked mirror).
+#
+# Default: false
+# WARNING: this may run a kubectl that is outside Kubernetes' version skew policy
+# and could be incompatible with your API server. Use with care.
+UseLatestIfNoCompatible = false
+
 # Directory where kubectl binaries are made accessible to all the users of the system
 SystemPath = "/opt/bin"
 
@@ -132,6 +142,12 @@ Timeout = 1
 KubeMirrorUrl = "https://dl.k8s.io"
 ```
 
-The behaviour can also be adjusted by using environment variables matching the
-config file: `KUBERLR_ALLOWDOWNLOAD`, `KUBERLR_SYSTEMPATH`, `KUBERLR_TIMEOUT`,
-`KUBERLR_KUBEMIRRORURL`, and so on.
+The behaviour can also be adjusted by using environment variables matching the config file:
+ | Key                 | Default | ENV                         | Description |
+ |---------------------|---------|-----------------------------|-------------|
+ | `AllowDownload`     | `true`  | `KUBERLR_ALLOWDOWNLOAD`     | Whether kuberlr may download a compatible `kubectl` from the upstream mirror. |
+ | `UseLatestIfNoCompatible` | `false` | `KUBERLR_USELATESTIFNOCOMPATIBLE` When **no compatible** local `kubectl` is found, use the **newest local** `kubectl` instead of failing **if downloads are disabled or the download attempt fails**. |
+ | `SystemPath`         | `/opt/bin`    | `KUBERLR_SYSTEMPATH`        | Additional directory to scan for system-wide `kubectl` binaries. |
+ | `KubeMirrorUrl`      | `https://dl.k8s.io`    | `KUBERLR_KUBEMIRRORURL`     | Custom upstream mirror for downloads. |
+ | `Timeout`            | `10`    | `KUBERLR_TIMEOUT`           | Timeout (seconds) for contacting the API server to detect version. |
+ 

--- a/cmd/kuberlr/main.go
+++ b/cmd/kuberlr/main.go
@@ -76,7 +76,9 @@ func kubectlWrapperMode(args []string) {
 
 	kubectlBin, err := versioner.EnsureCompatibleKubectlAvailable(
 		version,
-		v.GetBool("AllowDownload"))
+		v.GetBool("AllowDownload"),
+		v.GetBool("UseLatestIfNoCompatible"),
+	)
 	if err != nil {
 		klog.Fatalf("kuberlr: ensure compatible kubectl available: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ func (c *Cfg) Load() (*viper.Viper, error) {
 	v.SetDefault("SystemPath", common.SystemPath)
 	v.SetDefault("Timeout", DefaultTimeout)
 	v.SetDefault("KubeMirrorUrl", "https://dl.k8s.io")
+	v.SetDefault("UseLatestIfNoCompatible", false)
 
 	v.SetConfigType("toml")
 

--- a/internal/finder/versioner.go
+++ b/internal/finder/versioner.go
@@ -110,7 +110,7 @@ func (v *Versioner) EnsureCompatibleKubectlAvailable(version semver.Version, all
 
 	if !allowDownload {
 		if useLatestIfNoCompatible {
-			all := v.kFinder.AllKubectlBinaries(true /* reverseSort */)
+			all := v.kFinder.AllKubectlBinaries(true) // newest-first
 			if len(all) > 0 {
 				return all[0].Path, nil
 			}

--- a/internal/finder/versioner_test.go
+++ b/internal/finder/versioner_test.go
@@ -33,6 +33,7 @@ func TestEnsureCompatibleKubectlAvailableDownloadsKubectlBinaryWhenNeeded(t *tes
 		expectedToMakeDownloads  bool
 		downloadAllowed          bool
 		expectsError             bool
+		useLatestIfNoCompatible  bool
 	}{
 		{
 			name:                     "requested version can be satisfied by already downloaded kubectl binary",
@@ -40,6 +41,7 @@ func TestEnsureCompatibleKubectlAvailableDownloadsKubectlBinaryWhenNeeded(t *tes
 			requestedVersion:         semver.MustParse("1.30.2"),
 			expectedToMakeDownloads:  false,
 			downloadAllowed:          true,
+			useLatestIfNoCompatible:  false,
 			expectsError:             false,
 		},
 		{
@@ -48,6 +50,7 @@ func TestEnsureCompatibleKubectlAvailableDownloadsKubectlBinaryWhenNeeded(t *tes
 			requestedVersion:         semver.MustParse("1.9.0"),
 			expectedToMakeDownloads:  true,
 			downloadAllowed:          true,
+			useLatestIfNoCompatible:  false,
 			expectsError:             false,
 		},
 		{
@@ -56,6 +59,7 @@ func TestEnsureCompatibleKubectlAvailableDownloadsKubectlBinaryWhenNeeded(t *tes
 			requestedVersion:         semver.MustParse("2.4.0"),
 			expectedToMakeDownloads:  true,
 			downloadAllowed:          true,
+			useLatestIfNoCompatible:  false,
 			expectsError:             false,
 		},
 		{
@@ -64,6 +68,7 @@ func TestEnsureCompatibleKubectlAvailableDownloadsKubectlBinaryWhenNeeded(t *tes
 			requestedVersion:         semver.MustParse("2.4.0"),
 			expectedToMakeDownloads:  false,
 			downloadAllowed:          false,
+			useLatestIfNoCompatible:  false,
 			expectsError:             true,
 		},
 	}
@@ -98,7 +103,7 @@ func TestEnsureCompatibleKubectlAvailableDownloadsKubectlBinaryWhenNeeded(t *tes
 				preventRecursiveInvocationEnvName: fmt.Sprintf("KUBERLR_RESOLVING_VERSION_%d", rand.Intn(100)),
 			}
 
-			_, err := versioner.EnsureCompatibleKubectlAvailable(requestedVersion, tt.downloadAllowed)
+			_, err := versioner.EnsureCompatibleKubectlAvailable(requestedVersion, tt.downloadAllowed, tt.useLatestIfNoCompatible)
 			if tt.expectsError {
 				assert.Error(t, err)
 			} else {
@@ -323,4 +328,136 @@ func TestFindCompatibleKubectl(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fallbackTestFinder is a minimal stub that:
+// - always fails to find a compatible kubectl,
+// - returns a predefined list of local kubectl binaries.
+type fallbackTestFinder struct {
+	all KubectlBinaries // NOTE: named slice type to match iFinder exactly
+}
+
+// Adjust signatures if your real finder interface differs.
+func (f *fallbackTestFinder) FindCompatibleKubectl(_ semver.Version) (KubectlBinary, error) {
+	return KubectlBinary{}, fmt.Errorf("no compatible kubectl")
+}
+
+func (f *fallbackTestFinder) AllKubectlBinaries(reverseSort bool) KubectlBinaries {
+	out := make(KubectlBinaries, len(f.all))
+	copy(out, f.all)
+
+	// When reverseSort is true, we need newest-first order.
+	// Do a simple O(n^2) sort by version descending to avoid importing extra packages.
+	if reverseSort && len(out) > 1 {
+		for i := 0; i < len(out)-1; i++ {
+			for j := i + 1; j < len(out); j++ {
+				if out[j].Version.GT(out[i].Version) {
+					out[i], out[j] = out[j], out[i]
+				}
+			}
+		}
+	}
+	return out
+}
+
+// newFallbackVersioner wires a Versioner with our fallbackTestFinder.
+// NOTE: This assumes Versioner has a field named kFinder and the tests are in the same package.
+// If your Versioner must be constructed via a constructor, adapt accordingly.
+func newFallbackVersioner(ff *fallbackTestFinder) *Versioner {
+	v := &Versioner{}
+	// If your field name differs, change this assignment.
+	v.kFinder = ff
+	return v
+}
+
+func fallbackMustVer(t *testing.T, s string) semver.Version {
+	t.Helper()
+	v, err := semver.Parse(s)
+	if err != nil {
+		t.Fatalf("bad semver %q: %v", s, err)
+	}
+	return v
+}
+
+// Test: no compatible client, downloads disabled, opt-in enabled -> newest local is used.
+func TestEnsureCompatibleKubectlAvailable_FallbackToNewest_WhenOptIn(t *testing.T) {
+	t.Parallel()
+
+	ff := &fallbackTestFinder{
+		all: KubectlBinaries{
+			{Path: "/bin/kubectl-1.27.6", Version: fallbackMustVer(t, "1.27.6")},
+			{Path: "/bin/kubectl-1.30.1", Version: fallbackMustVer(t, "1.30.1")}, // newest
+			{Path: "/bin/kubectl-1.29.3", Version: fallbackMustVer(t, "1.29.3")},
+		},
+	}
+	v := newFallbackVersioner(ff)
+
+	server := fallbackMustVer(t, "1.24.0")
+
+	got, err := v.EnsureCompatibleKubectlAvailable(
+		server,
+		/*allowDownload=*/ false,
+		/*useLatestIfNoCompatible=*/ true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "/bin/kubectl-1.30.1"
+	if got != want {
+		t.Fatalf("want newest %s, got %s", want, got)
+	}
+}
+
+// Test: opt-in enabled but there are no local binaries -> still an error.
+func TestEnsureCompatibleKubectlAvailable_Fallback_NoLocals(t *testing.T) {
+	t.Parallel()
+
+	ff := &fallbackTestFinder{all: nil}
+	v := newFallbackVersioner(ff)
+
+	server := fallbackMustVer(t, "1.24.0")
+
+	if _, err := v.EnsureCompatibleKubectlAvailable(server, false, true); err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+// Download fails → fallback to newest local kubectl when the option is enabled.
+func TestEnsureCompatibleKubectlAvailable_DownloadFails_FallbackToNewest_WhenOptIn(t *testing.T) {
+	t.Parallel()
+
+	// Pick a server version that guarantees "no compatible" among the local set below.
+	requested := semver.MustParse("2.4.0")
+
+	// IMPORTANT: AllKubectlBinaries(true) is expected to return newest-first.
+	kubectlBinsNewestFirst := KubectlBinaries{
+		{Version: semver.MustParse("1.30.1"), Path: "path/to/kubectl-1.30.1"}, // newest
+		{Version: semver.MustParse("1.29.3"), Path: "path/to/kubectl-1.29.3"},
+		{Version: semver.MustParse("1.27.6"), Path: "path/to/kubectl-1.27.6"},
+	}
+
+	finderMock := NewMockiFinder(t)
+	// Versioner may call AllKubectlBinaries(true) before attempting download (to check compatibility)
+	// and again when handling the download error (to pick the newest). Allow two calls.
+	finderMock.EXPECT().AllKubectlBinaries(true).Return(kubectlBinsNewestFirst)
+	finderMock.EXPECT().AllKubectlBinaries(true).Return(kubectlBinsNewestFirst)
+
+	downloaderMock := NewMockdownloadHelper(t)
+	downloaderMock.EXPECT().
+		GetKubectlBinary(requested, mock.AnythingOfType("string")).
+		Return(fmt.Errorf("network unreachable"))
+
+	versioner := Versioner{
+		kFinder:                           finderMock,
+		downloader:                        downloaderMock,
+		preventRecursiveInvocationEnvName: fmt.Sprintf("KUBERLR_RESOLVING_VERSION_%d", rand.Intn(100)),
+	}
+
+	got, err := versioner.EnsureCompatibleKubectlAvailable(
+		requested,
+		/*allowDownload=*/ true,
+		/*useLatestIfNoCompatible=*/ true,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "path/to/kubectl-1.30.1", got)
 }

--- a/kuberlr.conf.example
+++ b/kuberlr.conf.example
@@ -2,6 +2,16 @@
 # Default true
 AllowDownload = true
 
+# When NO compatible local kubectl is found, opt-in to using the NEWEST local kubectl
+# instead of failing in these cases:
+#   1) downloads are disabled (AllowDownload = false), OR
+#   2) a download attempt fails (e.g., no network, blocked mirror).
+#
+# Default: false
+# WARNING: this may run a kubectl that is outside Kubernetes' version skew policy
+# and could be incompatible with your API server. Use with care.
+UseLatestIfNoCompatible = false
+
 # Directory where kubectl binaries are made accessible to all the users of the system
 # Default "/usr/bin"
 SystemPath = "/usr/bin"


### PR DESCRIPTION
With Internet disconnected (airgap):
```
% KUBERLR_ALLOWDOWNLOAD=1 \
KUBERLR_USELATESTIFNOCOMPATIBLE=1 \
./kuberlr kubectl get pods                 
I1002 13:52:40.345028   34202 versioner.go:121] Right kubectl missing, downloading version 1.24.17
I1002 13:52:40.349242   34202 versioner.go:132] download failed (error while trying to get contents of https://dl.k8s.io/release/v1.24.17/bin/darwin/arm64/kubectl.sha512: Get "https://dl.k8s.io/release/v1.24.17/bin/darwin/arm64/kubectl.sha512": dial tcp: lookup dl.k8s.io: no such host); falling back to newest local kubectl 1.26.9 at /Users/farcop/.kuberlr/darwin-arm64/kubectl1.26.9
No resources found in default namespace.
```