### PR TITLE
Bump golang version to v1.26.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ release:
 .PHONY: go-version-check
 go-version-check:
 	@[ $(GO_VERSION_MAJ) -ge 2 ] || \
-		[ $(GO_VERSION_MAJ) -eq 1 -a $(GO_VERSION_MIN) -ge 20 ] || (echo "FATAL: Go version should be >= 1.20.x" ; exit 1 ; )
+		[ $(GO_VERSION_MAJ) -eq 1 -a $(GO_VERSION_MIN) -ge 26 ] || (echo "FATAL: Go version should be >= 1.26.x" ; exit 1 ; )
 
 .PHONY: lint
 lint: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flavio/kuberlr
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -5,7 +5,7 @@ FROM registry.suse.com/bci/bci-busybox:${BCI_VERSION} AS final
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 AS xx
 
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.24 AS build
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.26 AS build
 
 ARG TARGETPLATFORM
 ARG PROJECT_PATH


### PR DESCRIPTION
https://github.com/rancherlabs/image-scanning/issues/10199

`rancher/kuberlr-kubectl` repo [consumes](https://github.com/rancher/kuberlr-kubectl/blob/main/package/Dockerfile#L2 ) latest tag (v0.6.1) of this 
repo which was tagged a year ago. Since then some depencies were bumped in main branch but there was no new tag.  This patch bumps golang version to 1.26.4 so that some CVEs' are fixed in https://github.com/rancherlabs/image-scanning/issues/10199. 

It would be great to cut a new tag (v0.6.2) or (v0.7.0) once this patch merges, so it can be consumed from `rancher/kuberlr-kubectl` repo, thanks!


